### PR TITLE
Build riscv64 wheels for sccache

### DIFF
--- a/.github/workflows/sccache.yml
+++ b/.github/workflows/sccache.yml
@@ -37,6 +37,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64
             features: reqwest/native-tls-vendored
+          - os: ubuntu-latest
+            target: riscv64
+            features: reqwest/native-tls-vendored
           - os: macos-latest
             target: x86_64
             features: reqwest/native-tls-vendored


### PR DESCRIPTION
Allow sccache to be used in maturin-action on riscv64 GitHub Actions runners (xref https://github.com/PyO3/maturin-action/pull/429) once these wheels are uploaded to PyPI.